### PR TITLE
[43기 김진평] ADD : 카카오 소셜 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn-debug.log*
 yarn-error.log*
 
 .eslintcache
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "aos": "^2.3.4",
+        "dotenv": "^16.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
@@ -7358,11 +7359,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -15123,6 +15124,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "aos": "^2.3.4",
+    "dotenv": "^16.0.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",

--- a/src/pages/SignIn/OAuth/OAuth.js
+++ b/src/pages/SignIn/OAuth/OAuth.js
@@ -1,0 +1,7 @@
+const KAKAO_API_KEY = process.env.REACT_APP_KAKAO_SOCIAL_LOGIN_API;
+const REDIRECT_URI = process.env.REACT_APP_REDIRECT_URI;
+
+const domainHost = `https://kauth.kakao.com`;
+const url = `/oauth/authorize?client_id=${KAKAO_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+export const KAKAO_AUTH_URL = `${domainHost}${url}`;

--- a/src/pages/SignIn/Redirect/Redirect.js
+++ b/src/pages/SignIn/Redirect/Redirect.js
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import useFetch from '../../../hooks/useFetch';
+import loadingGif from '../../../assets/images/1495.gif';
+import { useSetRecoilState } from 'recoil';
+import { isLoginedState } from '../../../recoil';
+import * as S from './Redirect.style';
+
+const Redirect = () => {
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const setIsLogined = useSetRecoilState(isLoginedState);
+  const beforeAddress = localStorage.getItem('before-address');
+
+  //인가코드 - 백엔드 통신시 사용
+  const code = searchParams.get('code');
+
+  //개발용 url
+  const url = '/data/loginToken.json';
+  const { loading, data, error } = useFetch(url);
+  useEffect(() => {
+    if (!loading) {
+      if (data?.accessToken) {
+        localStorage.removeItem('before-address');
+        localStorage.setItem('login-token', data.accessToken);
+        setIsLogined(true);
+        navigate(beforeAddress);
+      } else {
+        alert('로그인에 실패했습니다. 다시 시도해주시기 바랍니다.');
+      }
+    }
+  }, [loading]);
+
+  return (
+    <S.RedirectContainer>
+      {loading && <img src={loadingGif} alt="loading" />}
+    </S.RedirectContainer>
+  );
+};
+
+export default Redirect;

--- a/src/pages/SignIn/Redirect/Redirect.style.js
+++ b/src/pages/SignIn/Redirect/Redirect.style.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const RedirectContainer = styled.div`
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const LoadingImg = styled.img`
+  width: 48px;
+  height: 48px;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- dotenv 라이브러리를 통한 카카오 API Key 및 Redirect Uri 은닉화
- OAuth 컴포넌트 생성
- 카카오 소셜 로그인 이후 main으로 redirect

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. dotenv
- dotenv 라이브러리를 install하여 API Key 은닉화
 
2. OAuth 컴포넌트
- env파일의 API Key, Redirect Uri를 불러와 카카오 소셜 로그인 요청 파라미터로 조합 후 SignIn으로 export

3. 카카오 소셜 로그인 이후 main으로 redirect
- 소셜로그인 이후 카카오 development에 입력한 redirect uri로 페이지가 이동되어 필요한 인가 코드 추출 후 main컴포넌트로 redirect

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- dotenv를 통해 노출되면 안되는 key 은닉화 방법 습득
- react-router-dom의 Navigate를 통해 redirect 구현
- 동적 라우팅을 통한 필요 코드 추출

<br />

## :: 기타 질문 및 특이 사항
- 인가 코드를 동적 라우팅으로 사용해서 주소창에 인가 코드가 노출되는데 이 부분 보안상 괜찮을까요?
