### PR TITLE
[43기 김진평] ADD : 카카오 소셜 로그인 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "aos": "^2.3.4",
+        "dotenv": "^16.0.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.8.0",
@@ -7359,11 +7360,11 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -15124,6 +15125,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-transition-group": {

--- a/src/Router.js
+++ b/src/Router.js
@@ -21,7 +21,6 @@ const Router = () => {
         <Route path="/mypage" element={<Mypage />} />
         <Route path="/search" element={<Search />} />
         <Route path="/store" element={<Store />} />
-        <Route path="/store/:cateCode" element={<Store />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/pages/SignIn/OAuth/OAuth.js
+++ b/src/pages/SignIn/OAuth/OAuth.js
@@ -1,0 +1,7 @@
+const KAKAO_API_KEY = process.env.REACT_APP_KAKAO_SOCIAL_LOGIN_API;
+const REDIRECT_URI = process.env.REACT_APP_REDIRECT_URI;
+
+const domainHost = `https://kauth.kakao.com`;
+const url = `/oauth/authorize?client_id=${KAKAO_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+export const KAKAO_AUTH_URL = `${domainHost}${url}`;

--- a/src/pages/SignIn/Redirect/Redirect.js
+++ b/src/pages/SignIn/Redirect/Redirect.js
@@ -1,7 +1,54 @@
-import React from 'react';
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import useFetch from '../../../hooks/useFetch';
+import loadingGif from '../../../assets/images/1495.gif';
+import { useSetRecoilState } from 'recoil';
+import { isLoginedState } from '../../../recoil';
+import { API } from '../../../config';
+import * as S from './Redirect.style';
 
 const Redirect = () => {
-  return <div>Redirect</div>;
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const setIsLogined = useSetRecoilState(isLoginedState);
+  const beforeAddress = localStorage.getItem('before-address');
+
+  //인가코드 - 백엔드 통신시 사용
+  const authorizationCode = searchParams.get('code');
+
+  // FIXME - 개발용 로그인 토큰 url (로컬 통신)
+  //const devUrl = '/data/loginToken.json';
+
+  const params = {
+    method: 'GET',
+    headers: {
+      'Content-type': 'application/json;charset=utf-8',
+    },
+  };
+
+  const { loading, data } = useFetch(
+    `${API.KAKAO}?code=${authorizationCode}`,
+    params
+  );
+
+  useEffect(() => {
+    if (!loading) {
+      if (data?.result.accessToken) {
+        localStorage.removeItem('before-address');
+        localStorage.setItem('login-token', data.result.accessToken);
+        setIsLogined(true);
+        navigate(beforeAddress);
+      } else {
+        alert('로그인에 실패했습니다. 다시 시도해주시기 바랍니다.');
+      }
+    }
+  }, [loading]);
+
+  return (
+    <S.RedirectContainer>
+      {loading && <img src={loadingGif} alt="loading" />}
+    </S.RedirectContainer>
+  );
 };
 
 export default Redirect;

--- a/src/pages/SignIn/Redirect/Redirect.style.js
+++ b/src/pages/SignIn/Redirect/Redirect.style.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const RedirectContainer = styled.div`
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜 로그인 성공

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 카카오 소셜 로그인
- 프론트에서 로그인 버튼 클릭시 카카오 필수 동의 이후 Redirect.js페이지로 인가코드를 받음
- 인가코드를 가지고 백엔드와 통신해 JWT 적용된 accessToken 전달받음
- config.js에 백엔드 base_url, API 주소 설정

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 카카오 문서를 읽고 서비스를 사용할 수 있게 되었습니다.
- 백엔드와 통신을 진행하며 이전보다 이해도가 좋아진 것 같습니다.
<br />

## :: 기타 질문 및 특이 사항
- 
